### PR TITLE
FORUM-776: [Forum] Empty confirmation message when opening Watch List

### DIFF
--- a/forum/webapp/src/main/webapp/templates/forum/webui/UITopicDetail.gtmpl
+++ b/forum/webapp/src/main/webapp/templates/forum/webui/UITopicDetail.gtmpl
@@ -262,6 +262,7 @@
 							} else {
 								isView = true;
 							}
+							confirm = "";
 							if(action.equals("SetDeleteTopic")) {
 								confirm = " class=\"confirm\"";
 							}


### PR DESCRIPTION
Problem analysis:
- Confirmation message is only necessary for Delete option.

Fix description:
- Reset the confirmation flag for each action in the drop-down menu.
