### PR TITLE
FORUM-804: [IE8] Can not jump to the last reply when click on 'View the ...

### DIFF
--- a/forum/webapp/src/main/webapp/javascript/eXo/forum/UIForumPortlet.js
+++ b/forum/webapp/src/main/webapp/javascript/eXo/forum/UIForumPortlet.js
@@ -441,10 +441,9 @@
           var obj = document.getElementById(idLastPost);
           if (eXo.core.Browser.isIE()) {
             var correctOffset = 0;
-            if (obj.offsetParent) {
-              do {
-                correctOffset += obj.offsetTop;
-              } while (obj = obj.offsetParent);
+            while(obj.offsetParent) {
+              correctOffset += obj.offsetTop;
+              obj = obj.offsetParent;
             }
             $("html, body").scrollTop(correctOffset);
           } else {


### PR DESCRIPTION
...latest reply'

Fix description:
    - In IE, use scrollTo to scroll to specific item
