### PR TITLE
FORUM-541: UnsupportedOperationException when deleting or adding attachments

### DIFF
--- a/forum/service/src/main/java/org/exoplatform/forum/service/cache/model/data/PostData.java
+++ b/forum/service/src/main/java/org/exoplatform/forum/service/cache/model/data/PostData.java
@@ -2,6 +2,7 @@ package org.exoplatform.forum.service.cache.model.data;
 
 import java.util.Arrays;
 import java.util.Date;
+import java.util.ArrayList;
 
 import org.exoplatform.forum.common.cache.model.CachedData;
 import org.exoplatform.forum.service.ForumAttachment;
@@ -84,7 +85,7 @@ public class PostData  implements CachedData<Post> {
     post.setUserPrivate(this.userPrivate);
     post.setNumberAttach(this.numberAttach);
     if (this.attachments != null) {
-      post.setAttachments(Arrays.asList(this.attachments));
+      post.setAttachments(new ArrayList<ForumAttachment>(Arrays.asList(this.attachments)));
     }
 
     return post;

--- a/forum/service/src/main/java/org/exoplatform/forum/service/cache/model/data/TopicData.java
+++ b/forum/service/src/main/java/org/exoplatform/forum/service/cache/model/data/TopicData.java
@@ -2,6 +2,7 @@ package org.exoplatform.forum.service.cache.model.data;
 
 import java.util.Arrays;
 import java.util.Date;
+import java.util.ArrayList;
 
 import org.exoplatform.forum.common.cache.model.CachedData;
 import org.exoplatform.forum.service.ForumAttachment;
@@ -131,7 +132,7 @@ public class TopicData implements CachedData<Topic> {
     topic.setEmailNotification(this.emailNotification);
     topic.setVoteRating(this.voteRating);
     if (this.attachments != null) {
-      topic.setAttachments(Arrays.asList(this.attachments));
+      topic.setAttachments(new ArrayList<ForumAttachment>(Arrays.asList(this.attachments)));
     }
     return topic;
 


### PR DESCRIPTION
Problem analysis:
- During the update of a topic/post, the attachment cache data are inserted to topic/post object.
  These data are fixed-size Lists and therefore don't allow "add" or "remove" operation.

Fix description:
- Wrap attachment cache data by ArrayList when updating Topic/Post object.
