### PR TITLE
FORUM-541: UnsupportedOperationException when deleting or adding attachments

### DIFF
--- a/forum/webapp/src/main/java/org/exoplatform/forum/webui/popup/UITopicForm.java
+++ b/forum/webapp/src/main/java/org/exoplatform/forum/webui/popup/UITopicForm.java
@@ -302,7 +302,7 @@ public class UITopicForm extends BaseForumForm {
       String postId = topicId.replaceFirst(Utils.TOPIC, Utils.POST);
       Post post = getForumService().getPost(this.categoryId, this.forumId, this.topicId, postId);
       if (post != null && post.getAttachments() != null && post.getAttachments().size() > 0) {
-        this.attachments_.addAll((post.getAttachments());
+        this.attachments_.addAll(post.getAttachments());
         this.refreshUploadFileList();
       }
     }


### PR DESCRIPTION
Problem analysis:
- During the update of a topic/post, the attachment cache data are inserted to topic/post object. These data are fixed-size Lists and therefore don't allow "add" or "remove" operation.

Fix description:
- Wrap the attachments by resizable ArrayList when getting post information.
