### PR TITLE
COMMONS-374 exo.base.url doesn't take effect in Forum email notification

### DIFF
--- a/forum/webapp/src/main/java/org/exoplatform/forum/ForumUtils.java
+++ b/forum/webapp/src/main/java/org/exoplatform/forum/ForumUtils.java
@@ -130,9 +130,7 @@ public class ForumUtils {
 
   public static String createdForumLink(String type, String id, boolean isPrivate) {
     try {
-      PortalRequestContext portalContext = Util.getPortalRequestContext();
-      String fullUrl = ((HttpServletRequest) portalContext.getRequest()).getRequestURL().toString();
-      String host = fullUrl.substring(0, fullUrl.indexOf(SLASH, 8));
+      String host = CommonsUtils.getCurrentDomain();
       return new StringBuffer(host).append(createdSubForumLink(type, id, isPrivate)).toString();
     } catch (Exception e) {
       return id;


### PR DESCRIPTION
Fix description: use method getCurrentDomain from project Commons to get the host name - which is define by parameter exo.base.url in gatein/conf/exo.properties - in method createdForumLink of ForumUtils class in project Forum.
