### PR TITLE
FORUM-1094: "Go to the last read post" button doesn't work

### DIFF
--- a/forum/service/src/main/java/org/exoplatform/forum/service/impl/JCRDataStorage.java
+++ b/forum/service/src/main/java/org/exoplatform/forum/service/impl/JCRDataStorage.java
@@ -3112,11 +3112,10 @@ public class JCRDataStorage implements DataStorage, ForumNodeTypes {
 
         String query = Utils.getSQLQuery(isApproved, isHidden, isHidden, userLogin).toString();
         if (query.isEmpty() == false) {
-          sqlQuery.append(" AND (").append(sqlQuery).append(")");
+          sqlQuery.append(" AND (").append(query).append(")");
         }
         Calendar cal = postNode.getProperty(EXO_CREATED_DATE).getDate();
         sqlQuery.append(" AND (").append(EXO_CREATED_DATE).append(" <= TIMESTAMP '").append(ISO8601.format(cal)).append("')");
-        //
         NodeIterator iter = getNodeIteratorBySQLQuery(sProvider, sqlQuery.toString(), 0, 0, false);
         long size = iter.getSize();
         boolean isView = false;
@@ -3133,9 +3132,7 @@ public class JCRDataStorage implements DataStorage, ForumNodeTypes {
         return size;
       }
     } catch (Exception e) {
-      if (LOG.isDebugEnabled()) {
-        LOG.debug("Exception occurs when get last read index", e);
-      }
+      LOG.error("Exception occurs when getting last read index", e);
     }
     return 0;
   }


### PR DESCRIPTION
Problem analysis:
* The query concatenation in JCRDataStorage.getLastReadIndex is wrong.
  It always returns index of 0 due to an InvalidQueryException which is only visible in log at debug level.

Fix description:
* Fix the query concatenation.
* Throw exception to server console and server log if there is.