### PR TITLE
FORUM-1326: Get space pretty name to fix wrong urls in unified search

### DIFF
--- a/forum/service/src/main/java/org/exoplatform/forum/service/search/DiscussionSearchConnector.java
+++ b/forum/service/src/main/java/org/exoplatform/forum/service/search/DiscussionSearchConnector.java
@@ -31,6 +31,8 @@ import org.exoplatform.portal.mop.navigation.Scope;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.services.security.ConversationState;
+import org.exoplatform.social.core.space.model.Space;
+import org.exoplatform.social.core.space.spi.SpaceService;
 
 
 /**
@@ -40,6 +42,8 @@ public class DiscussionSearchConnector extends SearchServiceConnector {
   private static final Log LOG = ExoLogger.getLogger(DiscussionSearchConnector.class);
 
   private DataStorage storage;
+
+  private SpaceService spaceService;
                               //"/forum/skin/DefaultSkin/webui/skinIcons/48x48/defaultTopic.png";
   private String FIX_ICON = "/eXoSkin/skin/images/themes/default/Icons/AppIcons/uiIconAppDefault.png";
   
@@ -54,9 +58,10 @@ public class DiscussionSearchConnector extends SearchServiceConnector {
   private static final String FORMAT_DATE           = "EEEEE, MMMMMMMM d, yyyy K:mm a";  
 
 
-  public DiscussionSearchConnector(InitParams initParams, DataStorage storage) {
+  public DiscussionSearchConnector(InitParams initParams, DataStorage storage, SpaceService spaceService) {
     super(initParams);
     this.storage = storage;
+    this.spaceService = spaceService;
   }
   
   @Override
@@ -208,6 +213,12 @@ public class DiscussionSearchConnector extends SearchServiceConnector {
     //
     if (Utils.isEmpty(forumNavName)) {
       return CommonUtils.EMPTY_STR;
+    }
+    if(spaceService != null) {
+      Space space = spaceService.getSpaceByGroupId(spaceGroupId);
+      if(space != null){
+        groupId = space.getPrettyName();
+      }
     }
     path = groupId + CommonUtils.SLASH + forumNavName;
     

--- a/forum/service/src/test/java/org/exoplatform/forum/search/DiscussionSearchConnectorTestCase.java
+++ b/forum/service/src/test/java/org/exoplatform/forum/search/DiscussionSearchConnectorTestCase.java
@@ -36,6 +36,7 @@ import org.exoplatform.portal.mop.page.PageContext;
 import org.exoplatform.portal.mop.page.PageKey;
 import org.exoplatform.portal.mop.page.PageService;
 import org.exoplatform.portal.mop.page.PageState;
+import org.exoplatform.social.core.space.spi.SpaceService;
 import org.exoplatform.web.controller.metadata.ControllerDescriptor;
 import org.exoplatform.web.controller.metadata.DescriptorBuilder;
 import org.exoplatform.web.controller.router.Router;
@@ -156,9 +157,11 @@ public class DiscussionSearchConnectorTestCase extends BaseForumServiceTestCase 
     InitParams params = new InitParams();
     params.put("constructor.params", new PropertiesParam());
     
-    org.exoplatform.forum.service.DataStorage dataStorage = (org.exoplatform.forum.service.DataStorage) getService(org.exoplatform.forum.service.DataStorage.class);
-    
-    discussionSearchConnector = new DiscussionSearchConnector(params, dataStorage);
+    org.exoplatform.forum.service.DataStorage dataStorage = getService(org.exoplatform.forum.service.DataStorage.class);
+
+    SpaceService spaceService = getService(SpaceService.class);
+
+    discussionSearchConnector = new DiscussionSearchConnector(params, dataStorage, spaceService);
 
   }
 


### PR DESCRIPTION
Get space pretty name to fix wrong search URLs when a space is renamed