### PR TITLE
FORUM-1420: update the id of UIQuickSearchForm

### DIFF
--- a/forum/webapp/src/main/java/org/exoplatform/forum/webui/UIBreadcumbs.java
+++ b/forum/webapp/src/main/java/org/exoplatform/forum/webui/UIBreadcumbs.java
@@ -60,7 +60,7 @@ public class UIBreadcumbs extends UIContainer {
 
   private List<String>       path_         = new ArrayList<String>();
 
-  private String             QUICK_SEARCH  = "QuickSearchForm";
+  private String             QUICK_SEARCH  = "UIQuickSearchForm";
 
   public static final String FORUM_SERVICE = Utils.FORUM_SERVICE;
 
@@ -71,7 +71,7 @@ public class UIBreadcumbs extends UIContainer {
   private String             tooltipLink   = Utils.FORUM_SERVICE;
   
   public UIBreadcumbs() throws Exception {
-    forumService = (ForumService) ExoContainerContext.getCurrentContainer().getComponentInstanceOfType(ForumService.class);
+    forumService = (ForumService) ExoContainerContext.gCurrentContainer().getComponentInstanceOfType(ForumService.class);
     breadcumbs_.add(ForumUtils.FIELD_EXOFORUM_LABEL);
     path_.add(FORUM_SERVICE);
     addChild(UIQuickSearchForm.class, null, QUICK_SEARCH);


### PR DESCRIPTION
the problem was that the 'search' placeholder in the forum application was not translated into Arabic because the id of UIQuickSearchForm was wrong so i changed it to "UIQuickSearchForm" to match the key "UIQuickSearchForm.label.Search" in ForumPortlet_xx.properties.
