### PR TITLE
PLF-8448: Make sure that Unified search Exact match using double quotes is accurate. (#136)

### DIFF
--- a/application/common/src/main/java/org/exoplatform/forum/common/CommonUtils.java
+++ b/application/common/src/main/java/org/exoplatform/forum/common/CommonUtils.java
@@ -327,12 +327,12 @@ public class CommonUtils {
   }
   
   public static String processUnifiedSearchSearchCondition(String input) {
-    if (isEmpty(input) || input.indexOf("~") < 0 || input.indexOf("\\~") > 0) {
+    if (isEmpty(input) || (input.startsWith("\"") && input.endsWith("\"")) || input.indexOf("~") < 0 || input.indexOf("\\~") > 0) {
       return input;
     }
     StringBuilder builder = new StringBuilder();
     String[] tab = input.split(" ");
-    for (String s : tab){
+    for (String s : tab) {
       if (isEmpty(s)) continue;
       if (s.indexOf("~") > -1) {
         String searchTerm = s.split("~")[0];
@@ -354,7 +354,7 @@ public class CommonUtils {
    * @return 
    */
   public static String normalizeUnifiedSearchInput(String input) {
-    if (isEmpty(input)) {
+    if (isEmpty(input) || input.startsWith("\"") && input.endsWith("\"")) {
       return input;
     }
     StringBuilder builder = new StringBuilder();

--- a/forum/service/src/main/java/org/exoplatform/forum/service/impl/JCRDataStorage.java
+++ b/forum/service/src/main/java/org/exoplatform/forum/service/impl/JCRDataStorage.java
@@ -6017,6 +6017,7 @@ public class JCRDataStorage implements DataStorage, ForumNodeTypes {
       //String rootPath = categoryHome.getPath();
 
       //process query for asterisk
+      textQuery = textQuery.trim();
       textQuery = CommonUtils.processUnifiedSearchSearchCondition(textQuery);
       String asteriskQuery = CommonUtils.normalizeUnifiedSearchInput(textQuery);
       

--- a/forum/service/src/test/java/org/exoplatform/forum/search/DiscussionSearchConnectorTestCase.java
+++ b/forum/service/src/test/java/org/exoplatform/forum/search/DiscussionSearchConnectorTestCase.java
@@ -362,6 +362,50 @@ public class DiscussionSearchConnectorTestCase extends BaseForumServiceTestCase 
     
     forumService_.removeCategory(cateId);
   }
+
+  public void testSearchDataWithDoubleQuotes() throws Exception {
+    String cateId = getId(Utils.CATEGORY);
+    Category cat = createCategory(cateId);
+    cat.setCategoryName("My Topic Category");
+    forumService_.saveCategory(cat, true);
+
+    Forum forum = createdForum();
+    forum.setForumName("forum1");
+    forumService_.saveForum(cateId, forum, true);
+
+    Topic topic1 = createdTopic(USER_ROOT);
+    topic1.setTopicName("My Topic Abc");
+    topic1.setDescription("My Topic Abc Description");
+    forumService_.saveTopic(cateId, forum.getId(), topic1, true, false, new MessageBuilder());
+
+    Topic topic2 = createdTopic(USER_ROOT);
+    topic2.setTopicName("My Topic Second Abc");
+    topic2.setDescription("My Topic Second Abc Description");
+    forumService_.saveTopic(cateId, forum.getId(), topic2, true, false, new MessageBuilder());
+
+    Post post1 = createdPost();
+    post1.setName("Reply A1");
+    post1.setMessage("My Reply Abc");
+    forumService_.savePost(cateId, forum.getId(), topic1.getId(), post1, true, new MessageBuilder());
+    
+    Post post2 = createdPost();
+    post2.setName("Reply A2");
+    post2.setMessage("Second My Reply Abc");
+    forumService_.savePost(cateId, forum.getId(), topic2.getId(), post2, true, new MessageBuilder());
+    // Test without double quotes
+    assertEquals(0, discussionSearchConnector.search(context, null, Collections.<String>emptyList(), 0, 5, "relevancy", "ASC").size());
+    assertEquals(0, discussionSearchConnector.search(context, "", Collections.<String>emptyList(), 0, 5, "relevancy", "ASC").size());
+    assertEquals(2, discussionSearchConnector.search(context, "My Topic Abc", Collections.<String>emptyList(), 0, 5, "relevancy", "ASC").size());
+    assertEquals(2, discussionSearchConnector.search(context, "My Reply Abc", Collections.<String>emptyList(), 0, 5, "relevancy", "ASC").size());
+    // Test with double quotes for topic
+    assertEquals(2, discussionSearchConnector.search(context, "\"My Topic\"", Collections.<String>emptyList(), 0, 5, "relevancy", "ASC").size());
+    assertEquals(1, discussionSearchConnector.search(context, "\"My Topic Second\"", Collections.<String>emptyList(), 0, 5, "relevancy", "ASC").size());
+    // Test with double quotes for reply
+    assertEquals(2, discussionSearchConnector.search(context, "\"My Reply Abc\"", Collections.<String>emptyList(), 0, 5, "relevancy", "ASC").size());
+    assertEquals(1, discussionSearchConnector.search(context, "\"Second My\"", Collections.<String>emptyList(), 0, 5, "relevancy", "ASC").size());
+
+    forumService_.removeCategory(cateId);
+  }
   
   public void testSpecialCaseComplex() throws Exception {
     String cateId = getId(Utils.CATEGORY);


### PR DESCRIPTION
To fix this issue i made sure that the methods processUnifiedSearchSearchCondition and normalizeUnifiedSearchInput are not processed for double quoted phrases in unified search because the normalizeUnifiedSearchInput method removes the double quotes and replace them with asterisk for each beginning and end of each word of the phrase.