### PR TITLE
PLF-8448-01: Make sure that Unified search Exact match using double quotes is accurate.

### DIFF
--- a/application/common/src/main/java/org/exoplatform/forum/common/CommonUtils.java
+++ b/application/common/src/main/java/org/exoplatform/forum/common/CommonUtils.java
@@ -327,7 +327,7 @@ public class CommonUtils {
   }
   
   public static String processUnifiedSearchSearchCondition(String input) {
-    if (isEmpty(input) || (input.startsWith("\"") && input.endsWith("\"")) || input.indexOf("~") < 0 || input.indexOf("\\~") > 0) {
+    if (isEmpty(input) || input.indexOf("~") < 0 || input.indexOf("\\~") > 0) {
       return input;
     }
     StringBuilder builder = new StringBuilder();
@@ -354,8 +354,15 @@ public class CommonUtils {
    * @return 
    */
   public static String normalizeUnifiedSearchInput(String input) {
-    if (isEmpty(input) || input.startsWith("\"") && input.endsWith("\"")) {
+    if (isEmpty(input)) {
       return input;
+    }
+    // When searching for exact matching the input comes with (\") but for exact
+    // matching search in JCR queries, the searched word must be set between two
+    // double quote only, so when it is the case of exact matching search we remove
+    // all occurrences of '\'
+    if (input.startsWith("\\\"") && input.endsWith("\\\"")) {
+      return input.replaceAll("\\\\", "");
     }
     StringBuilder builder = new StringBuilder();
     String keySearch = removeExceptPattern(input);

--- a/forum/service/src/test/java/org/exoplatform/forum/search/DiscussionSearchConnectorTestCase.java
+++ b/forum/service/src/test/java/org/exoplatform/forum/search/DiscussionSearchConnectorTestCase.java
@@ -390,7 +390,7 @@ public class DiscussionSearchConnectorTestCase extends BaseForumServiceTestCase 
     
     Post post2 = createdPost();
     post2.setName("Reply A2");
-    post2.setMessage("Second My Reply Abc");
+    post2.setMessage("My Reply Abc second");
     forumService_.savePost(cateId, forum.getId(), topic2.getId(), post2, true, new MessageBuilder());
     // Test without double quotes
     assertEquals(0, discussionSearchConnector.search(context, null, Collections.<String>emptyList(), 0, 5, "relevancy", "ASC").size());
@@ -398,11 +398,12 @@ public class DiscussionSearchConnectorTestCase extends BaseForumServiceTestCase 
     assertEquals(2, discussionSearchConnector.search(context, "My Topic Abc", Collections.<String>emptyList(), 0, 5, "relevancy", "ASC").size());
     assertEquals(2, discussionSearchConnector.search(context, "My Reply Abc", Collections.<String>emptyList(), 0, 5, "relevancy", "ASC").size());
     // Test with double quotes for topic
-    assertEquals(2, discussionSearchConnector.search(context, "\"My Topic\"", Collections.<String>emptyList(), 0, 5, "relevancy", "ASC").size());
-    assertEquals(1, discussionSearchConnector.search(context, "\"My Topic Second\"", Collections.<String>emptyList(), 0, 5, "relevancy", "ASC").size());
+    assertEquals(2, discussionSearchConnector.search(context, "\\\"My Topic\\\"", Collections.<String>emptyList(), 0, 5, "relevancy", "ASC").size());
+    assertEquals(1, discussionSearchConnector.search(context, "\\\"My Topic Second\\\"", Collections.<String>emptyList(), 0, 5, "relevancy", "ASC").size());
     // Test with double quotes for reply
-    assertEquals(2, discussionSearchConnector.search(context, "\"My Reply Abc\"", Collections.<String>emptyList(), 0, 5, "relevancy", "ASC").size());
-    assertEquals(1, discussionSearchConnector.search(context, "\"Second My\"", Collections.<String>emptyList(), 0, 5, "relevancy", "ASC").size());
+    assertEquals(2, discussionSearchConnector.search(context, "\\\"My Reply Abc\\\"", Collections.<String>emptyList(), 0, 5, "relevancy", "ASC").size());
+    assertEquals(2, discussionSearchConnector.search(context, "\\\"Second\\\"", Collections.<String>emptyList(), 0, 5, "relevancy", "ASC").size());
+    assertEquals(0, discussionSearchConnector.search(context, "\\\"My Abc\\\"", Collections.<String>emptyList(), 0, 5,"relevancy", "ASC").size());
 
     forumService_.removeCategory(cateId);
   }


### PR DESCRIPTION
This fix comes to complete the previous one by fixing the check condition by startsWith which didn't work properly.
When searching for exact matching the input comes with (\") but for exact matching search in JCR queries, the searched word must be surrounded by two double quote only, so when it is the case of exact matching search we remove all occurrences of '\'.